### PR TITLE
Fix: number of lanes, usleep and time trigger_mode

### DIFF
--- a/drivers/src/make_overlay_dts_xavier-devkit.py
+++ b/drivers/src/make_overlay_dts_xavier-devkit.py
@@ -2527,7 +2527,7 @@ str_i2c_imx490_n_p2 = """
 
         mode0 {/*mode IMX490_MODE_2880X1860_CROP_30FPS*/
           mclk_khz = \"24000\";
-          num_lanes = \"2\";
+          num_lanes = \"4\";
           tegra_sinterface = \"serial_a\";
           vc_id = \"0\";
           discontinuous_clk = \"no\";

--- a/drivers/src/tier4-gw5300.c
+++ b/drivers/src/tier4-gw5300.c
@@ -60,19 +60,19 @@ static u8 slave_10fps[] = {
                           , 0x00, 0x42
 };
 
-static u8 master_20fps[] = { 
+static u8 master_20fps[] = {
                              0x33, 0x47, 0x0B, 0x00, 0x00, 0x00, 0x12, 0x00
                            , 0x80, 0x03, 0x00, 0x00, 0x00, 0x5A, 0x00, 0x00
                            , 0x00, 0x74
 };
 
-static u8 slave_20fps[] = { 
+static u8 slave_20fps[] = {
                             0x33, 0x47, 0x0B, 0x00, 0x00, 0x00, 0x12, 0x00
                           , 0x80, 0x03, 0x00, 0x00, 0x00, 0x5F, 0x00, 0x00
                           , 0x00, 0x79
 };
 
-static u8 slave_30fps[] = { 
+static u8 slave_30fps[] = {
                             0x33, 0x47, 0x0B, 0x00, 0x00, 0x00, 0x12, 0x00
                           , 0x80, 0x03, 0x00, 0x00, 0x00, 0x55, 0x00, 0x00
                           , 0x00, 0x6F
@@ -138,12 +138,12 @@ static int tier4_gw5300_send_and_recv_msg(struct device *dev, u8 *wdata, int wda
 
   err = i2c_transfer(priv->i2c_client->adapter, msg, 2);
 
-  if (err < 0)
+  if (err <= 0)
   {
     dev_err(dev, "[%s] : i2c_transer send message failed. %d: slave addr = 0x%x\n", __func__, err, msg[0].addr);
   }
 
-  return err;
+  return err;  //  the total number of bytes to have been sent or recived
 }
 
 uint8_t calcCheckSum(const uint8_t *data, size_t size){
@@ -159,10 +159,10 @@ int tier4_gw5300_set_integration_time_on_aemode(struct device *dev, u16 max_inte
 #define MS_TO_LINE_UNIT 80
   u8    buf[6];
   int ret = 0;
-  
+
   u8 cmd_integration_max[22] = {0x33, 0x47, 0x0f, 0x00, 0x00, 0x00, 0x55, 0x00, 0x80, 0x05, 0x00, 0x15, 0x00, 0x01, 0x00, 0x04, 0x00, 0x70, 0x03, 0x00, 0x00, 0x00}; // val = 0x70, 0x03, 0x00, 0x00
-  u8 cmd_integration_min[20] = {0x33, 0x47, 0x0d, 0x00, 0x00, 0x00, 0x55, 0x00, 0x80, 0x05, 0x00, 0x21, 0x00, 0x01, 0x00, 0x02, 0x00, 0x70, 0x03, 0x00}; //val = 0x70, 0x03 
-  
+  u8 cmd_integration_min[20] = {0x33, 0x47, 0x0d, 0x00, 0x00, 0x00, 0x55, 0x00, 0x80, 0x05, 0x00, 0x21, 0x00, 0x01, 0x00, 0x02, 0x00, 0x70, 0x03, 0x00}; //val = 0x70, 0x03
+
   const size_t max_val_pos = 17;
   const size_t min_val_pos = 17;
   uint32_t min_line =  min_integration_time / 1000 * MS_TO_LINE_UNIT;
@@ -171,7 +171,7 @@ int tier4_gw5300_set_integration_time_on_aemode(struct device *dev, u16 max_inte
   uint8_t b2 = (max_line >> 8)&0xFF;
   uint8_t b3 = 0;
   uint8_t b4 = 0;
-  
+
   cmd_integration_max[max_val_pos] = b1;
   cmd_integration_max[max_val_pos+1] = b2;
   cmd_integration_max[max_val_pos+2] = b3;
@@ -189,9 +189,9 @@ int tier4_gw5300_set_integration_time_on_aemode(struct device *dev, u16 max_inte
 
 
     msleep(20);
-  ret += tier4_gw5300_send_and_recv_msg(dev, cmd_integration_max, sizeof(cmd_integration_max), buf, sizeof(buf));   
+  ret += tier4_gw5300_send_and_recv_msg(dev, cmd_integration_max, sizeof(cmd_integration_max), buf, sizeof(buf));
     msleep(20);
-  ret += tier4_gw5300_send_and_recv_msg(dev, cmd_integration_min, sizeof(cmd_integration_min), buf, sizeof(buf));   
+  ret += tier4_gw5300_send_and_recv_msg(dev, cmd_integration_min, sizeof(cmd_integration_min), buf, sizeof(buf));
 
   return ret;
 
@@ -201,15 +201,15 @@ EXPORT_SYMBOL(tier4_gw5300_set_integration_time_on_aemode);
 int tier4_gw5300_set_distortion_correction(struct device *dev, bool val)
 {
 int ret = 0;
-  u8 	buf[6];
-	u8 cmd_dwp_on[]={0x33, 0x47, 0x06, 0x00, 0x00, 0x00, 0x4d, 0x00, 0x80, 0x04, 0x00, 0x01, 0x52};
-	u8 cmd_dwp_off[]={0x33, 0x47, 0x03, 0x00, 0x00, 0x00, 0x45, 0x00, 0x80, 0x42};
-    
-	if(val){
-		ret += tier4_gw5300_send_and_recv_msg(dev, cmd_dwp_on, sizeof(cmd_dwp_on), buf, sizeof(buf));   
-	}else{	
-		ret += tier4_gw5300_send_and_recv_msg(dev, cmd_dwp_off, sizeof(cmd_dwp_off), buf, sizeof(buf));   
-	}
+  u8  buf[6];
+  u8 cmd_dwp_on[]={0x33, 0x47, 0x06, 0x00, 0x00, 0x00, 0x4d, 0x00, 0x80, 0x04, 0x00, 0x01, 0x52};
+  u8 cmd_dwp_off[]={0x33, 0x47, 0x03, 0x00, 0x00, 0x00, 0x45, 0x00, 0x80, 0x42};
+
+  if(val){
+    ret += tier4_gw5300_send_and_recv_msg(dev, cmd_dwp_on, sizeof(cmd_dwp_on), buf, sizeof(buf));
+  }else{
+    ret += tier4_gw5300_send_and_recv_msg(dev, cmd_dwp_off, sizeof(cmd_dwp_off), buf, sizeof(buf));
+  }
   return ret;
 }
 EXPORT_SYMBOL(tier4_gw5300_set_distortion_correction);

--- a/drivers/src/tier4-imx490.c
+++ b/drivers/src/tier4-imx490.c
@@ -42,6 +42,8 @@ MODULE_SOFTDEP("pre: tier4_gw5300");
 MODULE_SOFTDEP("pre: tier4_fpga");
 MODULE_SOFTDEP("pre: tier4_isx021");
 
+#define USE_DISTORTION_CORRECTION
+
 // Register Address
 
 #define IMX490_DEFAULT_FRAME_LENGTH (2000)
@@ -486,7 +488,8 @@ static int tier4_imx490_set_exposure(struct tegracam_device *tc_dev, s64 val)
 // --------------------------------------------------------------------------------------
 //  Enable Distortion Coreection
 // --------------------------------------------------------------------------------------
-#if 0
+#ifdef USE_DISTORTION_CORRECTION
+
 static int tier4_imx490_set_distortion_correction(struct tegracam_device *tc_dev, bool val)
 {
   int err = 0;
@@ -596,10 +599,10 @@ static int tier4_imx490_start_one_streaming(struct tegracam_device *tc_dev)
 
   dev_info(dev, "[%s] : trigger_mode = %d\n", __func__, trigger_mode);
 
-  if (trigger_mode > 0)
-  {
+//  if (trigger_mode > 0)
+//  {
     priv->fsync_mode = trigger_mode;
-  }
+//  }
 
   switch (priv->fsync_mode)
   {
@@ -703,34 +706,34 @@ static int tier4_imx490_start_one_streaming(struct tegracam_device *tc_dev)
       return err;
   }
 
-  usleep_range(50000, 51000);
+  usleep_range(100000, 110000);
 
   err = tier4_max9296_start_streaming(priv->dser_dev, dev);
 
-#if 0
+#ifdef USE_DISTORTION_CORRECTION
 
   if (enable_distortion_correction == 0xCAFE)
   {
-	  // if not set kernel param, read device tree param
-	  if (priv->distortion_correction == false)
-	  {
-		  err = tier4_imx490_set_distortion_correction(tc_dev, priv->distortion_correction);
+    // if not set kernel param, read device tree param
+    if (priv->distortion_correction == false)
+    {
+      err = tier4_imx490_set_distortion_correction(tc_dev, priv->distortion_correction);
 
-		  if (err)
-		  {
-			  dev_err(dev, "[%s] : Disabling Distortion Correction  failed\n", __func__);
-			  goto exit;
-		  }
-		  msleep(20);
-	  }
+      if (err)
+      {
+        dev_err(dev, "[%s] : Disabling Distortion Correction  failed\n", __func__);
+        goto exit;
+      }
+      msleep(20);
+    }
    }else{
-		  err = tier4_imx490_set_distortion_correction(tc_dev, enable_distortion_correction==1);
-		  if (err)
-		  {
-			  dev_err(dev, "[%s] : Setup Distortion Correction  failed\n", __func__);
-			  goto exit;
-		  }
-		  msleep(20);
+      err = tier4_imx490_set_distortion_correction(tc_dev, enable_distortion_correction==1);
+      if (err)
+      {
+        dev_err(dev, "[%s] : Setup Distortion Correction  failed\n", __func__);
+        goto exit;
+      }
+      msleep(20);
    }
 
 #endif
@@ -740,8 +743,7 @@ static int tier4_imx490_start_one_streaming(struct tegracam_device *tc_dev)
     dev_err(dev, "[%s] : tier4_max9296_start_stream() failed\n", __func__);
     return err;
   }
-  
-  
+
   msleep(1000);
   tier4_gw5300_set_integration_time_on_aemode(priv->isp_dev, shutter_time_max, shutter_time_min);
   dev_info(dev, "[%s] :  Camera has started streaming\n", __func__);
@@ -1162,7 +1164,7 @@ static int tier4_imx490_board_setup(struct tier4_imx490 *priv)
                 dev_err(dev, "[%s]  : Parameter of fpga-generate-fsync  is invalid .\n", __func__);
                 goto error;
             }
-        } else {    
+        } else {
             if (!strcmp(str_value, "true")) {
                 priv->g_ctx.fpga_generate_fsync = true;
             }


### PR DESCRIPTION
- For C2,
   - Fixed the number of lanes in the case of Nvidia Xavier devkit
   - Fixed the bug of the activation of distortion correction.
   - Fixed the bug regarding the `trigger_mode` setting (in the case of setting `0`)