### PR TITLE
Fix/max9295 clock output setting

### DIFF
--- a/drivers/debian/changelog
+++ b/drivers/debian/changelog
@@ -1,3 +1,9 @@
+tier4-camera-gmsl (1.4.4) UNRELEASED; urgency=medium
+
+  * Fixed MAX9295 output clock frequency settings. This fixes the camera frame rate in the case of master mode. 
+
+ -- tier4 <tier4@RQX58G>  Thu, 20 Jun 2024 15:22:30 +0900
+
 tier4-camera-gmsl (1.4.3) focal; urgency=medium
 
   * Fixed cache coherency issue.

--- a/drivers/debian/prerm
+++ b/drivers/debian/prerm
@@ -2,7 +2,7 @@
 
 #!/bin/sh
 NAME=tier4-camera-gmsl
-VERSION=1.4.3
+VERSION=1.4.4
 KERNEL_REL=$(uname -r)
 set -e
 case "$1" in

--- a/drivers/dkms.conf
+++ b/drivers/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="tier4-camera-gmsl"
-PACKAGE_VERSION="1.4.3"
+PACKAGE_VERSION="1.4.4"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE="make all -j$PROCS_NUM"

--- a/drivers/src/tier4-max9295.c
+++ b/drivers/src/tier4-max9295.c
@@ -480,10 +480,10 @@ int tier4_max9295_setup_control(struct device *dev)
   /* delay to settle link */
   msleep(100);
 
-  /* Set RCLKOUT soruce to the reference PLL clock*/
+  /* Set RCLKOUT source to the reference PLL clock */
   err = tier4_max9295_write_reg(dev, MAX9295_CLK_OUTPUT_ADDR, 0x03);
 
-  /* No need?*/
+  /* No need? */
   usleep_range(10000, 11000);
 
   /* PLL setting & Reset PLL */

--- a/drivers/src/tier4-max9295.c
+++ b/drivers/src/tier4-max9295.c
@@ -31,6 +31,7 @@
 
 #define MAX9295_DEV_ADDR 0x0000
 #define MAX9295_PIPE_EN_ADDR 0x0002
+#define MAX9295_CLK_OUTPUT_ADDR 0x0003
 #define MAX9295_CTRL0_ADDR 0x0010
 
 #define MAX9295_I2C4_ADDR 0x0044
@@ -479,6 +480,17 @@ int tier4_max9295_setup_control(struct device *dev)
   /* delay to settle link */
   msleep(100);
 
+  /* Set RCLKOUT soruce to the reference PLL clock*/
+  err = tier4_max9295_write_reg(dev, MAX9295_CLK_OUTPUT_ADDR, 0x03);
+
+  /* No need?*/
+  usleep_range(10000, 11000);
+
+  /* PLL setting & Reset PLL */
+  err = tier4_max9295_write_reg(dev, MAX9295_REF_VTG0_ADDR, 0x5A);
+  usleep_range(10000, 11000);
+//  err = tier4_max9295_write_reg(dev, MAX9295_REG570_ADDR, 0x0C);
+
   for (i = 0; i < ARRAY_SIZE(addr_offset); i += 3)
   {
     if ((g_ctx->ser_reg << 1) == addr_offset[i])
@@ -518,6 +530,10 @@ int tier4_max9295_setup_control(struct device *dev)
   tier4_max9295_write_reg(dev, MAX9295_SRC_PWDN_ADDR, MAX9295_PWDN_GPIO);
   tier4_max9295_write_reg(dev, MAX9295_SRC_CTRL_ADDR, MAX9295_RESET_SRC);
   tier4_max9295_write_reg(dev, MAX9295_SRC_OUT_RCLK_ADDR, MAX9295_SRC_RCLK);
+
+  /* PLL setting & Enable PLL */
+  tier4_max9295_write_reg(dev, MAX9295_REF_VTG0_ADDR, 0x59);
+
 
   g_ctx->serdev_found = true;
 


### PR DESCRIPTION
This PR fixes the unintended frame rate settings.

## Applicable cameras
- C1
- C2

## Applicable modes
- Master mode