### PR TITLE
Feat/support orin devkit 3541

### DIFF
--- a/drivers/debian/changelog
+++ b/drivers/debian/changelog
@@ -1,4 +1,10 @@
-tier4-camera-gmsl (1.4.4) UNRELEASED; urgency=medium
+tier4-camera-gmsl (1.4.5) focal; urgency=medium
+
+  * Added L4T 35.4.1 support for Nvidia Jetson AGX Orin development kit.
+
+ -- tier4 <camera@tier4.jp>  Mon, 26 Aug 2024 15:36:53 +0900
+
+tier4-camera-gmsl (1.4.4) focal; urgency=medium
 
   * Fixed MAX9295 output clock frequency settings. This fixes the camera frame rate in the case of master mode. 
 

--- a/drivers/debian/prerm
+++ b/drivers/debian/prerm
@@ -2,7 +2,7 @@
 
 #!/bin/sh
 NAME=tier4-camera-gmsl
-VERSION=1.4.4
+VERSION=1.4.5
 KERNEL_REL=$(uname -r)
 set -e
 case "$1" in

--- a/drivers/dkms.conf
+++ b/drivers/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="tier4-camera-gmsl"
-PACKAGE_VERSION="1.4.4"
+PACKAGE_VERSION="1.4.5"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE="make all -j$PROCS_NUM"

--- a/drivers/src/Makefile
+++ b/drivers/src/Makefile
@@ -166,6 +166,14 @@ else ifeq ($(L4T_RELEASE_MAIN), R35)
                 TARGET_ISX021_IMX490_DTS := tier4-isx021-imx490-gmsl-device-tree-overlay-orin-devkit-r3521
                 TARGET_IMX490_DTS        := tier4-imx490-gmsl-device-tree-overlay-orin-devkit-r3521
                 MAKE_OVERLAY_DTS_CMD     := make_overlay_dts_orin-devkit.py  r35.2.1
+            else ifeq ($(L4T_RELEASE_MAJOR), 4) # 35.4.1
+                KERNELRELEASE                   := 5.10.104-tegra
+                TARGET_ISX021_DTS               := tier4-isx021-gmsl-device-tree-overlay-orin-devkit-r3521
+                TARGET_IMX490_DTS               := tier4-imx490-gmsl-device-tree-overlay-orin-devkit-r3521
+                TARGET_IMX728_DTS               := tier4-imx728-gmsl-device-tree-overlay-orin-devkit-r3521
+                TARGET_ISX021_IMX490_DTS        := tier4-isx021-imx490-gmsl-device-tree-overlay-orin-devkit-r3521
+                TARGET_ISX021_IMX490_IMX728_DTS := tier4-isx021-imx490-imx728-gmsl-device-tree-overlay-orin-devkit-r3521
+                MAKE_OVERLAY_DTS_CMD            := make_overlay_dts_orin-devkit.py  r35.4.1
             else
                 KERNELRELEASE            := Unknown
                 TARGET_ISX021_DTS        := Unknown

--- a/drivers/src/make_overlay_dts_orin-devkit.py
+++ b/drivers/src/make_overlay_dts_orin-devkit.py
@@ -2937,7 +2937,7 @@ l4t_revision = args[1].upper()
 
 if l4t_revision == "R35.1":
     str_rev_num = "351"
-elif l4t_revision == "R35.2.1":
+elif l4t_revision == "R35.2.1" or "R35.4.1":
     str_rev_num = "3521"
 else:
     print(" Error!! : 1st argument should be R35.1 or R35.2.1")
@@ -2968,6 +2968,29 @@ if total_num_args > 10:
     print(" ***** Error! : " + args[0] + " should be from 2 to 8 arguments. *****\n")
     usage()
     sys.exit()
+
+print(f"{l4t_revision=}")
+
+# Replacing for R35.4.1.
+# This is due to the implementation of `min_gain_val` being -1 in L4T R35.4.1. 
+if l4t_revision == "R35.4.1":
+    str_i2c_isx021_0_p2 = str_i2c_isx021_0_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_isx021_1_p2 = str_i2c_isx021_1_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_isx021_2_p2 = str_i2c_isx021_2_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_isx021_3_p2 = str_i2c_isx021_3_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_isx021_4_p2 = str_i2c_isx021_4_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_isx021_5_p2 = str_i2c_isx021_5_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_isx021_6_p2 = str_i2c_isx021_6_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_isx021_7_p2 = str_i2c_isx021_7_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+
+    str_i2c_imx490_0_p2 = str_i2c_imx490_0_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_imx490_1_p2 = str_i2c_imx490_1_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_imx490_2_p2 = str_i2c_imx490_2_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_imx490_3_p2 = str_i2c_imx490_3_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_imx490_4_p2 = str_i2c_imx490_4_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_imx490_5_p2 = str_i2c_imx490_5_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_imx490_6_p2 = str_i2c_imx490_6_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
+    str_i2c_imx490_7_p2 = str_i2c_imx490_7_p2.replace('min_gain_val = "0"', 'min_gain_val = "1"')
 
 for i in range(MAX_NUM_CAMERAS):
     if i & 0x0 == 0:

--- a/drivers/src/make_overlay_dts_orin-devkit.py
+++ b/drivers/src/make_overlay_dts_orin-devkit.py
@@ -2940,7 +2940,7 @@ if l4t_revision == "R35.1":
 elif l4t_revision == "R35.2.1" or "R35.4.1":
     str_rev_num = "3521"
 else:
-    print(" Error!! : 1st argument should be R35.1 or R35.2.1")
+    print(" Error!! : 1st argument should be R35.1 or R35.2.1 or R35.4.1")
     usage()
     str_rev_num = "000"
 
@@ -2968,8 +2968,6 @@ if total_num_args > 10:
     print(" ***** Error! : " + args[0] + " should be from 2 to 8 arguments. *****\n")
     usage()
     sys.exit()
-
-print(f"{l4t_revision=}")
 
 # Replacing for R35.4.1.
 # This is due to the implementation of `min_gain_val` being -1 in L4T R35.4.1. 

--- a/drivers/src/make_overlay_dts_orin-devkit.py
+++ b/drivers/src/make_overlay_dts_orin-devkit.py
@@ -2937,7 +2937,7 @@ l4t_revision = args[1].upper()
 
 if l4t_revision == "R35.1":
     str_rev_num = "351"
-elif l4t_revision == "R35.2.1" or "R35.4.1":
+elif (l4t_revision == "R35.2.1") or (l4t_revision == "R35.4.1"):
     str_rev_num = "3521"
 else:
     print(" Error!! : 1st argument should be R35.1 or R35.2.1 or R35.4.1")


### PR DESCRIPTION
This PR adds the support L4T R35.4.1 (JetPack 5.1.2) for the Nvidia Jetson AGX Orin development kit.

- Modified Makefile
- Changed the dts generation Python script to avoid Nvidia's VI bug
- Incremented version to 1.4.5