### PR TITLE
Raise GMSL2 clock rate for C3 on RQX-59G

### DIFF
--- a/tools/dts_generator/make_overlay_dts_roscube-orin.py
+++ b/tools/dts_generator/make_overlay_dts_roscube-orin.py
@@ -2318,7 +2318,7 @@ str_i2c_imx728_n_p2 = """
           line_length = "4050";
           inherent_gain = "1";
           pix_clk_hz = "23328000";
-          serdes_pix_clk_hz = "250000000";
+          serdes_pix_clk_hz = "350000000";
 
           gain_factor = "10";
           min_gain_val = "0";   /* dB  */


### PR DESCRIPTION
The `serdes_pix_clk_hz` parameter on the RQX-59G device tree for the IMX728 sensor is set to 250MHz, but I observe a nvcsi failure under that rate:
```
Jul 16 05:25:03 tegra-ubuntu kernel: (NULL device *): vi_capture_control_message: NULL VI channel received
Jul 16 05:25:03 tegra-ubuntu kernel: t194-nvcsi 13e40000.host1x:nvcsi@15a00000: csi5_stream_close: Error in closing stream_id=4, csi_port=4
Jul 16 05:25:03 tegra-ubuntu kernel: (NULL device *): vi_capture_control_message: NULL VI channel received
Jul 16 05:25:03 tegra-ubuntu kernel: t194-nvcsi 13e40000.host1x:nvcsi@15a00000: csi5_stream_open: VI channel not found for stream- 4 vc- 0
```
Raising the clock rate to 350MHz to align with the Anvil settings fixes this issue.