### PR TITLE
Add DTS runtime adaptation and dedup tools for overlay hotplug

### DIFF
--- a/scripts/common/hotplug/camera-hotplug.sh
+++ b/scripts/common/hotplug/camera-hotplug.sh
@@ -8,22 +8,57 @@ fi
 
 BOARD=$1
 L4T_REVISION=$2
-SCRIPT_PATH="$(realpath $0)"
-cd "$(dirname $SCRIPT_PATH)"
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+GENERATOR="$REPO_ROOT/tools/dts_generator/make_overlay_dts_${BOARD}.py"
+DEDUP="$REPO_ROOT/tools/dts_generator/dedup_overlay_dts.py"
+OVERLAY_DIR="$SCRIPT_DIR/overlay"
+BASE_DTSI="$REPO_ROOT/tools/dts_generator/dtsi/tegra-camera-base-r36.dtsi"
 
 set -eux
 
-mkdir -p overlay
-cd overlay
+mkdir -p "$OVERLAY_DIR"
+cd "$OVERLAY_DIR"
 rm -f *.dts *.dtbo
-"../../../../tools/dts_generator/make_overlay_dts_$BOARD.py" "$L4T_REVISION" ${@:3}
-dtc -O dtb -o target.dtbo -@ $(ls *.dts)
 
+# Step 1: Generate DTS source
+"$GENERATOR" "$L4T_REVISION" ${@:3}
+
+# Step 2: Unload sensor driver and remove previous overlays
 sudo modprobe -r tier4_imx728 || true
 sudo rmdir /sys/kernel/config/device-tree/overlays/camera/ || true
+sudo rmdir /sys/kernel/config/device-tree/overlays/camera-base/ || true
 
+# Step 3: If the base DTB lacks camera pipeline nodes (VI ports, NVCSI
+# channels, camera-platform), apply the base camera dtsi as a separate
+# overlay first.  This is needed for flash configs that don't include
+# tegra234-orin-agx-cti-csi.dtsi (e.g. "base").  Without this, later
+# fragments that use target-path to reference these nodes would fail
+# because the kernel resolves all target-path values against the
+# unmodified base tree before applying any overlay fragments.
+if [ ! -d /proc/device-tree/tegra-capture-vi/ports ] && [ -f "$BASE_DTSI" ]; then
+    BASE_TMP=$(mktemp -d)
+    (echo '/dts-v1/; /plugin/;'; cat "$BASE_DTSI") > "$BASE_TMP/base.dts"
+    sudo dtc -O dtb -o "$BASE_TMP/base.dtbo" -@ "$BASE_TMP/base.dts"
+    sudo mkdir -p /sys/kernel/config/device-tree/overlays/camera-base/
+    sudo cp "$BASE_TMP/base.dtbo" /sys/kernel/config/device-tree/overlays/camera-base/dtbo
+    echo 1 | sudo tee /sys/kernel/config/device-tree/overlays/camera-base/status
+    rm -rf "$BASE_TMP"
+fi
+
+# Step 4: Dedup labels and compile.  This MUST run after the base overlay
+# (step 3) so that dedup sees camera labels (vi_port0, csi_chan0, etc.)
+# in /proc/device-tree/__symbols__/ and strips them from the overlay DTS.
+# Without this ordering, dedup would find nothing to strip, and the camera
+# overlay would carry duplicate phandle definitions that trigger the
+# EINVAL check in overlay.c:add_changeset_node() (see §5 in the analysis).
+sudo python3 "$DEDUP" --in-place -v *.dts
+sudo dtc -O dtb -o target.dtbo -@ $(ls *.dts)
+
+# Step 5: Apply the camera overlay
 sudo mkdir -p /sys/kernel/config/device-tree/overlays/camera/
 sudo cp target.dtbo /sys/kernel/config/device-tree/overlays/camera/dtbo
 echo 1 | sudo tee /sys/kernel/config/device-tree/overlays/camera/status
 
+# Step 6: Reload sensor driver
 sudo modprobe tier4-imx728

--- a/scripts/common/hotplug/camera-hotplug.sh
+++ b/scripts/common/hotplug/camera-hotplug.sh
@@ -11,9 +11,9 @@ L4T_REVISION=$2
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 GENERATOR="$REPO_ROOT/tools/dts_generator/make_overlay_dts_${BOARD}.py"
+ADAPT_OVERLAY="$REPO_ROOT/tools/dts_generator/adapt_overlay_for_runtime.py"
 DEDUP="$REPO_ROOT/tools/dts_generator/dedup_overlay_dts.py"
 OVERLAY_DIR="$SCRIPT_DIR/overlay"
-BASE_DTSI="$REPO_ROOT/tools/dts_generator/dtsi/tegra-camera-base-r36.dtsi"
 
 set -eux
 
@@ -21,44 +21,80 @@ mkdir -p "$OVERLAY_DIR"
 cd "$OVERLAY_DIR"
 rm -f *.dts *.dtbo
 
-# Step 1: Generate DTS source
+# Step 1: Generate DTS source (boot-time-compatible overlay)
 "$GENERATOR" "$L4T_REVISION" ${@:3}
 
-# Step 2: Unload sensor driver and remove previous overlays
-sudo modprobe -r tier4_imx728 || true
-sudo rmdir /sys/kernel/config/device-tree/overlays/camera/ || true
-sudo rmdir /sys/kernel/config/device-tree/overlays/camera-base/ || true
+# Step 2: Unload camera modules.
+# modprobe -r accepts multiple modules; modprobe (load) does NOT — additional
+# args are treated as module parameters.  So unload uses multi-module syntax
+# but reload (step 6) must use separate calls.
+#
+# tegra-camera / tegra_camera_platform / nvhost-capture / nvhost-nvcsi cannot
+# be unloaded (host1x device bindings hold module refs and the remove() path
+# crashes).  They stay resident; the overlay + NVCSI/VI/sensor reload is
+# sufficient for re-probing.
+sudo modprobe -r tier4-imx728 tier4-imx490 tier4-isx021 2>/dev/null || true
+sudo modprobe -r tier4_gw5300 2>/dev/null || true
+sudo modprobe -r nvhost-isp5 nvhost-vi5 nvhost-nvcsi-t194 2>/dev/null || true
 
-# Step 3: If the base DTB lacks camera pipeline nodes (VI ports, NVCSI
-# channels, camera-platform), apply the base camera dtsi as a separate
-# overlay first.  This is needed for flash configs that don't include
-# tegra234-orin-agx-cti-csi.dtsi (e.g. "base").  Without this, later
-# fragments that use target-path to reference these nodes would fail
-# because the kernel resolves all target-path values against the
-# unmodified base tree before applying any overlay fragments.
-if [ ! -d /proc/device-tree/tegra-capture-vi/ports ] && [ -f "$BASE_DTSI" ]; then
-    BASE_TMP=$(mktemp -d)
-    (echo '/dts-v1/; /plugin/;'; cat "$BASE_DTSI") > "$BASE_TMP/base.dts"
-    sudo dtc -O dtb -o "$BASE_TMP/base.dtbo" -@ "$BASE_TMP/base.dts"
-    sudo mkdir -p /sys/kernel/config/device-tree/overlays/camera-base/
-    sudo cp "$BASE_TMP/base.dtbo" /sys/kernel/config/device-tree/overlays/camera-base/dtbo
-    echo 1 | sudo tee /sys/kernel/config/device-tree/overlays/camera-base/status
-    rm -rf "$BASE_TMP"
-fi
+# Step 2b: Reset GMSL serdes state.
+# The MAX9296 deserializer retains link configuration from the previous overlay.
+# Without reset, a different sensor type cannot establish the GMSL link.
+#
+# TODO: This i2cset reset is a workaround. The RESET_ALL should ideally be
+#       performed in the kernel driver (e.g. MAX9296 probe or a dedicated
+#       reset function) rather than from a shell script. Additionally, whether
+#       i2cset is truly necessary (vs serdes module reload alone) has not been
+#       verified in a clean environment. See analysis doc "残存課題" for details.
+#
+# TODO: Bus numbers 10-13 are hardcoded for CTI Anvil. Other boards will
+#       have different I2C mux topology.
+#
+# MAX9296B register 0x0010 (CTRL0):
+#   bit 7: RESET_ALL      — full chip reset (equivalent to power cycle)
+#   bit 6: RESET_LINK     — reset GMSL PHY, stays in reset until cleared
+#   bit 5: RESET_ONESHOT  — reset GMSL PHY + data pipelines, auto-clears
+#
+# Send RESET_ALL BEFORE unloading serdes modules — the I2C mux routing is
+# only reliable while the kernel drivers are still managing the bus.
+# After reset, the link takes up to 100ms to re-establish (datasheet).
+for bus in 10 11 12 13; do
+    sudo i2cset -f -y "$bus" 0x48 0x00 0x10 0x80 i 2>/dev/null || true
+done
+sleep 3
+sudo modprobe -r tier4_max9296 tier4_max9295 2>/dev/null || true
 
-# Step 4: Dedup labels and compile.  This MUST run after the base overlay
-# (step 3) so that dedup sees camera labels (vi_port0, csi_chan0, etc.)
-# in /proc/device-tree/__symbols__/ and strips them from the overlay DTS.
-# Without this ordering, dedup would find nothing to strip, and the camera
-# overlay would carry duplicate phandle definitions that trigger the
-# EINVAL check in overlay.c:add_changeset_node() (see §5 in the analysis).
+sudo rmdir /sys/kernel/config/device-tree/overlays/camera/ 2>/dev/null || true
+
+# Step 3: Adapt overlay for kernel runtime compatibility.
+# The generator produces a self-contained boot-time overlay with embedded
+# base DTSI.  The kernel's overlay infrastructure is stricter than the
+# bootloader: it pre-resolves all target-path values and rejects duplicate
+# property updates.  adapt_overlay_for_runtime.py transforms the overlay by
+# resolving target-paths against the live device tree and merging fragments
+# that target the same node.
+sudo python3 "$ADAPT_OVERLAY" --in-place -v *.dts
+
+# Step 4: Dedup labels that conflict with the live device tree's __symbols__
+# to avoid phandle conflicts in overlay.c:add_changeset_node().
 sudo python3 "$DEDUP" --in-place -v *.dts
-sudo dtc -O dtb -o target.dtbo -@ $(ls *.dts)
 
-# Step 5: Apply the camera overlay
+# Step 5: Compile and apply the overlay
+sudo dtc -O dtb -o target.dtbo -@ $(ls *.dts)
 sudo mkdir -p /sys/kernel/config/device-tree/overlays/camera/
 sudo cp target.dtbo /sys/kernel/config/device-tree/overlays/camera/dtbo
 echo 1 | sudo tee /sys/kernel/config/device-tree/overlays/camera/status
 
-# Step 6: Reload sensor driver
-sudo modprobe tier4-imx728
+# Step 6: Reload camera modules.
+# modprobe (load) only accepts ONE module per invocation; additional args are
+# treated as module parameters.  Each module must be loaded separately.
+# Reload serdes first (must be present before sensor drivers probe).
+sudo modprobe tier4_max9295
+sudo modprobe tier4_max9296
+sleep 2
+sudo modprobe nvhost-nvcsi-t194
+sudo modprobe nvhost-vi5
+sudo modprobe nvhost-isp5
+sudo modprobe tier4-imx728 2>/dev/null || true
+sudo modprobe tier4-imx490 2>/dev/null || true
+sudo modprobe tier4-isx021 2>/dev/null || true

--- a/tools/dts_generator/adapt_overlay_for_runtime.py
+++ b/tools/dts_generator/adapt_overlay_for_runtime.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Adapt DTS overlay for kernel runtime application.
+
+The Linux kernel's overlay infrastructure resolves ALL target-path values
+before applying any fragments (unlike bootloaders which apply sequentially).
+It also rejects overlays where multiple fragments modify the same property.
+
+This tool transforms a boot-time-compatible DTS overlay for runtime use:
+  1. Resolves target-path values against the live device tree
+  2. Wraps fragments whose target-path doesn't exist in the live tree
+  3. Merges fragments targeting the same path (last-writer-wins)
+
+NOTE: This script must run on the target device because it reads the live
+device tree from /proc/device-tree/ to resolve target-path values.
+
+Usage:
+  adapt_overlay_for_runtime.py [--in-place] [-v] [--dt-dir DIR] file.dts [...]
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import OrderedDict
+from typing import Dict, List, Optional, Sequence, Tuple
+
+DEFAULT_DT_DIR = '/proc/device-tree'
+
+
+# ---------------------------------------------------------------------------
+# Low-level DTS text helpers
+# ---------------------------------------------------------------------------
+
+def _skip_comment(text: str, pos: int) -> int:
+    """Skip a comment starting at *pos*.  Returns position after it."""
+    if text[pos:pos + 2] == '//':
+        end = text.find('\n', pos)
+        return (end + 1) if end != -1 else len(text)
+    if text[pos:pos + 2] == '/*':
+        end = text.find('*/', pos + 2)
+        return (end + 2) if end != -1 else len(text)
+    return pos
+
+
+def _find_matching_brace(text: str, start: int) -> int:
+    """Return index of the ``}`` that matches the ``{`` at *start*."""
+    assert text[start] == '{', f'Expected {{ at {start}, got {text[start]!r}'
+    depth = 1
+    pos = start + 1
+    while pos < len(text) and depth > 0:
+        ch = text[pos]
+        if ch == '/' and pos + 1 < len(text) and text[pos + 1] in '/*':
+            pos = _skip_comment(text, pos)
+            continue
+        if ch == '"':
+            pos += 1
+            while pos < len(text) and text[pos] != '"':
+                if text[pos] == '\\':
+                    pos += 1
+                pos += 1
+            pos += 1
+            continue
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+        pos += 1
+    return pos - 1
+
+
+# ---------------------------------------------------------------------------
+# Overlay node tree (for merging)
+# ---------------------------------------------------------------------------
+
+class DtsNode:
+    """Minimal representation of a DTS node for deep-merging overlays."""
+
+    __slots__ = ('label', 'properties', 'children')
+
+    def __init__(self) -> None:
+        self.label: str = ''
+        self.properties: List[Tuple[str, str]] = []   # (key, full_text)
+        self.children: 'OrderedDict[str, DtsNode]' = OrderedDict()
+
+
+def _prop_key(full_text: str) -> str:
+    """Extract the property name from a full property string."""
+    eq = full_text.find('=')
+    if eq != -1:
+        return full_text[:eq].strip()
+    return full_text.split()[0] if full_text.strip() else ''
+
+
+def _parse_node_body(text: str) -> DtsNode:
+    """Parse the text *between* braces of a DTS node."""
+    node = DtsNode()
+    pos = 0
+    length = len(text)
+
+    while pos < length:
+        # skip whitespace and semicolons
+        while pos < length and text[pos] in ' \t\n\r;':
+            pos += 1
+        if pos >= length:
+            break
+
+        # skip comments
+        if text[pos] == '/' and pos + 1 < length and text[pos + 1] in '/*':
+            pos = _skip_comment(text, pos)
+            continue
+
+        # Try to match a child node: [label :] name { body };
+        m = re.match(r'((\w+)\s*:\s*)?([\w@,.+#/-]+)\s*\{', text[pos:])
+        if m:
+            label = m.group(2) or ''
+            name = m.group(3)
+            brace_start = pos + m.end() - 1
+            brace_end = _find_matching_brace(text, brace_start)
+            child_body = text[brace_start + 1:brace_end]
+
+            child = _parse_node_body(child_body)
+            child.label = label
+
+            if name in node.children:
+                _merge_nodes(node.children[name], child)
+            else:
+                node.children[name] = child
+
+            pos = brace_end + 1
+            continue
+
+        # Match a property (everything up to the next unquoted `;`)
+        prop_start = pos
+        while pos < length:
+            ch = text[pos]
+            if ch == ';':
+                break
+            if ch == '"':
+                pos += 1
+                while pos < length and text[pos] != '"':
+                    if text[pos] == '\\':
+                        pos += 1
+                    pos += 1
+            if ch == '{':
+                # Shouldn't happen if well-formed, but bail out
+                break
+            pos += 1
+
+        if pos > prop_start and text[pos:pos + 1] == ';':
+            prop_text = text[prop_start:pos].strip()
+            if prop_text:
+                key = _prop_key(prop_text)
+                node.properties.append((key, prop_text))
+            pos += 1
+            continue
+
+        pos += 1
+
+    return node
+
+
+def _merge_nodes(base: DtsNode, overlay: DtsNode) -> None:
+    """Deep-merge *overlay* into *base*.  Overlay values win."""
+    if overlay.label:
+        base.label = overlay.label
+
+    # Build map of existing base properties by key
+    existing: Dict[str, int] = {}
+    for i, (key, _) in enumerate(base.properties):
+        if key not in existing:
+            existing[key] = i
+
+    # Update existing properties in-place, append new ones
+    for key, text in overlay.properties:
+        if key in existing:
+            idx = existing[key]
+            base.properties[idx] = (key, text)
+        else:
+            base.properties.append((key, text))
+            existing[key] = len(base.properties) - 1
+
+    # Merge children recursively
+    for name, child in overlay.children.items():
+        if name in base.children:
+            _merge_nodes(base.children[name], child)
+        else:
+            base.children[name] = child
+
+
+def _serialize_node(node: DtsNode, indent: str = '') -> str:
+    """Serialize a DtsNode back to DTS text."""
+    parts: List[str] = []
+    for _, prop_text in node.properties:
+        parts.append(f'{indent}\t{prop_text};')
+    for name, child in node.children.items():
+        label_prefix = f'{child.label}: ' if child.label else ''
+        parts.append(f'{indent}\t{label_prefix}{name} {{')
+        parts.append(_serialize_node(child, indent + '\t'))
+        parts.append(f'{indent}\t}};')
+    return '\n'.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Fragment extraction and reassembly
+# ---------------------------------------------------------------------------
+
+class Fragment:
+    """A parsed DTS overlay fragment."""
+    __slots__ = ('name', 'target_path', 'target_label', 'overlay_body')
+
+    def __init__(self, name: str, target_path: Optional[str],
+                 target_label: Optional[str], overlay_body: str) -> None:
+        self.name = name
+        self.target_path = target_path
+        self.target_label = target_label
+        self.overlay_body = overlay_body
+
+
+_FRAG_RE = re.compile(r'([\w-]+@\d+)\s*\{')
+_TARGET_PATH_RE = re.compile(r'target-path\s*=\s*"([^"]*)"')
+_TARGET_LABEL_RE = re.compile(r'target\s*=\s*<&(\w+)>')
+
+
+def _extract_fragments(dts_text: str) -> Tuple[str, List[Fragment]]:
+    """Extract all fragments from *dts_text*.
+
+    Returns ``(preamble, fragments)`` where *preamble* is the text before
+    the first ``/ {`` block (``/dts-v1/;``, ``/plugin/;``, comments, etc.).
+    """
+    fragments: List[Fragment] = []
+
+    # Find all root blocks: / { ... };
+    root_re = re.compile(r'(?:^|\n)(\s*/\s*)\{')
+    preamble_end = 0
+    preamble = ''
+
+    for match in root_re.finditer(dts_text):
+        if preamble_end == 0:
+            preamble = dts_text[:match.start()]
+        brace_pos = match.start() + match.group(0).index('{')
+        if dts_text[match.start()] == '\n':
+            brace_pos = match.start() + match.group(0).index('{')
+        brace_end = _find_matching_brace(dts_text, brace_pos)
+        root_body = dts_text[brace_pos + 1:brace_end]
+        preamble_end = brace_end + 1
+
+        # Parse fragments at depth 0 inside the root block
+        pos = 0
+        while pos < len(root_body):
+            while pos < len(root_body) and root_body[pos] in ' \t\n\r;':
+                pos += 1
+            if pos >= len(root_body):
+                break
+            if root_body[pos] == '/' and pos + 1 < len(root_body) and root_body[pos + 1] in '/*':
+                pos = _skip_comment(root_body, pos)
+                continue
+
+            m = _FRAG_RE.match(root_body, pos)
+            if not m:
+                pos += 1
+                continue
+
+            frag_name = m.group(1)
+            fb_start = root_body.index('{', m.start())
+            fb_end = _find_matching_brace(root_body, fb_start)
+            frag_body = root_body[fb_start + 1:fb_end]
+
+            target_path: Optional[str] = None
+            target_label: Optional[str] = None
+            tp = _TARGET_PATH_RE.search(frag_body)
+            if tp:
+                target_path = tp.group(1)
+            else:
+                tl = _TARGET_LABEL_RE.search(frag_body)
+                if tl:
+                    target_label = tl.group(1)
+
+            ov = re.search(r'__overlay__\s*\{', frag_body)
+            if ov:
+                ov_brace = frag_body.index('{', ov.start())
+                ov_end = _find_matching_brace(frag_body, ov_brace)
+                overlay_body = frag_body[ov_brace + 1:ov_end]
+                fragments.append(Fragment(frag_name, target_path,
+                                          target_label, overlay_body))
+
+            pos = fb_end + 1
+
+    return preamble, fragments
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_path(target_path: str, dt_dir: str) -> Tuple[str, List[str]]:
+    """Find the longest existing prefix of *target_path* in the live DT.
+
+    Returns ``(existing_prefix, remaining_components)``.
+    """
+    path = target_path.rstrip('/')
+    if path == '' or path == '/':
+        return '/', []
+    components = path.split('/')[1:]  # drop leading ''
+
+    for i in range(len(components), 0, -1):
+        prefix = '/' + '/'.join(components[:i])
+        if os.path.isdir(os.path.join(dt_dir, prefix.lstrip('/'))):
+            return prefix, list(components[i:])
+
+    return '/', list(components)
+
+
+def _wrap_body(overlay_body: str, remaining: List[str]) -> str:
+    """Wrap *overlay_body* in nested node blocks for *remaining* path parts."""
+    body = overlay_body
+    for component in reversed(remaining):
+        body = f'\n\t\t\t{component} {{{body}\n\t\t\t}};'
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Main adaptation logic
+# ---------------------------------------------------------------------------
+
+def adapt_overlay(dts_text: str, dt_dir: str, verbose: bool = False) -> str:
+    """Adapt *dts_text* for kernel runtime overlay application."""
+    preamble, fragments = _extract_fragments(dts_text)
+
+    if not os.path.isdir(dt_dir):
+        if verbose:
+            print(f'  [adapt] {dt_dir} not found, skipping',
+                  file=sys.stderr)
+        return dts_text
+
+    # Phase 1: resolve target-paths and wrap overlay bodies
+    resolved: List[Tuple[str, Fragment]] = []  # (resolved_path, fragment)
+    for frag in fragments:
+        if frag.target_label is not None:
+            # target = <&label> — pass through unchanged
+            resolved.append(('__label__:' + frag.target_label, frag))
+            continue
+
+        if frag.target_path is None:
+            continue
+
+        existing, remaining = _resolve_path(frag.target_path, dt_dir)
+        if remaining:
+            if verbose:
+                orig = frag.target_path
+                print(f'  [adapt] {orig} -> {existing} + /{"/".join(remaining)}',
+                      file=sys.stderr)
+            frag.overlay_body = _wrap_body(frag.overlay_body, remaining)
+            frag.target_path = existing
+        resolved.append((frag.target_path, frag))
+
+    # Phase 2: group fragments by resolved target-path
+    groups: OrderedDict[str, List[Fragment]] = OrderedDict()
+    for key, frag in resolved:
+        groups.setdefault(key, []).append(frag)
+
+    # Phase 3: merge groups
+    merged_fragments: List[Tuple[str, Fragment]] = []
+    for key, group in groups.items():
+        if len(group) == 1:
+            merged_fragments.append((key, group[0]))
+            continue
+
+        if verbose:
+            names = ', '.join(f.name for f in group)
+            print(f'  [adapt] merging {len(group)} fragments '
+                  f'targeting {key}: {names}', file=sys.stderr)
+
+        # Deep merge all overlay bodies
+        base_node = _parse_node_body(group[0].overlay_body)
+        for frag in group[1:]:
+            overlay_node = _parse_node_body(frag.overlay_body)
+            _merge_nodes(base_node, overlay_node)
+
+        merged_body = _serialize_node(base_node, '\t\t')
+        result_frag = Fragment(
+            name=group[0].name,
+            target_path=group[0].target_path if not key.startswith('__label__:') else None,
+            target_label=group[0].target_label if key.startswith('__label__:') else None,
+            overlay_body='\n' + merged_body + '\n\t\t' if merged_body else '',
+        )
+        merged_fragments.append((key, result_frag))
+
+    # Phase 4: reassemble DTS
+    parts = [preamble.rstrip('\n'), '\n/ {\n']
+    for i, (key, frag) in enumerate(merged_fragments):
+        if key.startswith('__label__:'):
+            label = key[len('__label__:'):]
+            parts.append(f'\tfragment@{i} {{\n')
+            parts.append(f'\t\ttarget = <&{label}>;\n')
+        else:
+            parts.append(f'\tfragment@{i} {{\n')
+            parts.append(f'\t\ttarget-path = "{frag.target_path}";\n')
+        parts.append(f'\t\t__overlay__ {{{frag.overlay_body}}};\n')
+        parts.append(f'\t}};\n')
+    parts.append('};\n')
+
+    return ''.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description='Adapt DTS overlay for kernel runtime application.')
+    ap.add_argument('files', nargs='+', metavar='FILE',
+                    help='DTS files to process')
+    ap.add_argument('--in-place', action='store_true',
+                    help='Overwrite input files')
+    ap.add_argument('-v', '--verbose', action='store_true',
+                    help='Print diagnostic messages to stderr')
+    ap.add_argument('--dt-dir', default=DEFAULT_DT_DIR,
+                    help='Path to the live device tree '
+                         f'(default: {DEFAULT_DT_DIR})')
+    args = ap.parse_args()
+
+    for path in args.files:
+        if args.verbose:
+            print(f'adapt: {path}', file=sys.stderr)
+        with open(path, 'r', encoding='utf-8') as f:
+            original = f.read()
+
+        result = adapt_overlay(original, args.dt_dir, verbose=args.verbose)
+
+        if args.in_place:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(result)
+        else:
+            sys.stdout.write(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/dts_generator/dedup_overlay_dts.py
+++ b/tools/dts_generator/dedup_overlay_dts.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Strip duplicate label definitions from DTS overlay files.
+
+Reads the base device-tree symbol names from /proc/device-tree/__symbols__/
+and removes label definitions (``label: node {``) from the input DTS files
+where the label already exists in the base tree.  This prevents phandle
+conflicts and __symbols__ duplicates when applying overlays to boards whose
+base DTB pre-defines those labels (e.g. CTI Anvil).
+
+All ``<&label>`` phandle references are preserved.  After label stripping,
+``dtc -@`` can no longer resolve them locally and instead emits __fixups__
+entries, which the kernel resolves against the base tree at apply time.
+
+NOTE: This script must run on the target device because it reads label names
+from /proc/device-tree/__symbols__/ to detect conflicts with the live tree.
+
+Usage:
+    dedup_overlay_dts.py [--base-symbols-dir DIR] [--in-place] [-v] [input ...]
+
+If --base-symbols-dir is missing (e.g. cross-compiling on a host), the script
+warns to stderr and passes through unchanged.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# Matches DTS label definitions:  ``  vi_in0: endpoint {``
+#   group(1) = leading whitespace
+#   group(2) = label name
+#   group(3) = rest of the line (node-name and anything after)
+LABEL_DEF_RE = re.compile(r'^(\s*)(\w+):\s+(\S+)', re.MULTILINE)
+
+# Matches phandle references:  ``<&some_label>``
+LABEL_REF_RE = re.compile(r'<&(\w+)>')
+
+
+def read_base_symbols(symbols_dir):
+    """Return the set of symbol names present in the base device tree."""
+    try:
+        return set(os.listdir(symbols_dir))
+    except FileNotFoundError:
+        return None
+    except PermissionError:
+        return None
+
+
+def strip_labels(dts_text, base_symbols, verbose=False):
+    """Remove label definitions for labels that exist in *base_symbols*.
+
+    Returns (modified_text, set_of_stripped_labels).
+    """
+    stripped = set()
+
+    def replacer(m):
+        indent = m.group(1)
+        label = m.group(2)
+        rest = m.group(3)
+        if label in base_symbols:
+            stripped.add(label)
+            return indent + rest
+        return m.group(0)
+
+    result = LABEL_DEF_RE.sub(replacer, dts_text)
+
+    if verbose and stripped:
+        names = ', '.join(sorted(stripped))
+        print(f'stripped {len(stripped)} labels: {names}', file=sys.stderr)
+
+    return result, stripped
+
+
+def find_remaining_local_labels(dts_text):
+    """Return the set of labels still defined locally in *dts_text*."""
+    return {m.group(2) for m in LABEL_DEF_RE.finditer(dts_text)}
+
+
+def validate_references(dts_text, base_symbols, stripped_labels):
+    """Check that no ``<&label>`` reference is orphaned.
+
+    A reference is orphaned if its label was stripped locally AND does not
+    exist in the base tree symbols (so it can't be resolved as a __fixups__
+    entry either).
+
+    Returns a list of orphaned label names (empty if all OK).
+    """
+    local_labels = find_remaining_local_labels(dts_text)
+    referenced = {m.group(1) for m in LABEL_REF_RE.finditer(dts_text)}
+
+    orphaned = []
+    for ref in sorted(referenced):
+        if ref in local_labels:
+            continue  # still defined locally
+        if ref in base_symbols:
+            continue  # will become a __fixups__ entry
+        orphaned.append(ref)
+
+    return orphaned
+
+
+def process_file(path, base_symbols, in_place=False, verbose=False):
+    """Process a single DTS file.  Returns True on success."""
+    with open(path, 'r') as f:
+        original = f.read()
+
+    modified, stripped = strip_labels(original, base_symbols, verbose=verbose)
+
+    orphaned = validate_references(modified, base_symbols, stripped)
+    if orphaned:
+        names = ', '.join(orphaned)
+        print(f'ERROR: {path}: orphaned references after dedup: {names}',
+              file=sys.stderr)
+        return False
+
+    if in_place:
+        with open(path, 'w') as f:
+            f.write(modified)
+    else:
+        sys.stdout.write(modified)
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Strip duplicate label definitions from DTS overlay files.')
+    parser.add_argument('input_files', nargs='*', metavar='FILE',
+                        help='DTS files to process (default: stdin)')
+    parser.add_argument('--base-symbols-dir', default='/proc/device-tree/__symbols__/',
+                        help='Directory containing base tree symbol names '
+                             '(default: /proc/device-tree/__symbols__/)')
+    parser.add_argument('-i', '--in-place', action='store_true',
+                        help='Modify files in place (default: write to stdout)')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Print stripped labels to stderr')
+    args = parser.parse_args()
+
+    base_symbols = read_base_symbols(args.base_symbols_dir)
+    if base_symbols is None:
+        print(f'WARNING: {args.base_symbols_dir} not found or not readable; '
+              f'passing through unchanged', file=sys.stderr)
+        # Pass through: just cat input to output
+        for path in args.input_files:
+            with open(path, 'r') as f:
+                sys.stdout.write(f.read())
+        return 0
+
+    if not args.input_files:
+        # Read from stdin
+        original = sys.stdin.read()
+        modified, stripped = strip_labels(original, base_symbols,
+                                         verbose=args.verbose)
+        orphaned = validate_references(modified, base_symbols, stripped)
+        if orphaned:
+            names = ', '.join(orphaned)
+            print(f'ERROR: <stdin>: orphaned references after dedup: {names}',
+                  file=sys.stderr)
+            return 1
+        sys.stdout.write(modified)
+        return 0
+
+    ok = True
+    for path in args.input_files:
+        if not process_file(path, base_symbols, in_place=args.in_place,
+                            verbose=args.verbose):
+            ok = False
+
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/dts_generator/make_overlay_dts_anvil.py
+++ b/tools/dts_generator/make_overlay_dts_anvil.py
@@ -133,76 +133,6 @@ gmsl_dser_fragments = [
 ]
 
 
-class I2cMuxInfra:
-    """Holds references to the I2C mux sub-channel nodes so that camera nodes
-    can be added after the camera list is built.  This avoids creating separate
-    FragmentNode instances that use target-path to reference nodes created by
-    the mux fragment — the kernel resolves ALL target-path values before
-    applying any overlay fragments, so self-referencing paths fail."""
-
-    def __init__(self, gmsl_dsers: Sequence[DeviceTreeNode]) -> None:
-        self.i2c_channels = [
-            DeviceTreeNode(f'i2c@{i}')
-                .properties([
-                    'status = "okay"',
-                    f'reg = <{i}>',
-                    'i2c-mux,deselect-on-exit',
-                    '#address-cells = <1>',
-                    '#size-cells = <0>',
-                ])
-                .nodes([gmsl_dsers[i]])
-            for i in range(4)
-        ]
-
-        self.fragments: List[FragmentNode] = [
-            FragmentNode(target_path='/bus@0/i2c@31e0000')
-                .overlay_nodes([
-                    DeviceTreeNode('tca9544@72')
-                        .properties([
-                            'status = "okay"',
-                            'compatible = "nxp,pca9544"',
-                            'reg = <0x72>',
-                            '#address-cells = <1>',
-                            '#size-cells = <0>',
-                            'vcc-supply = <&vdd_1v8_sys>',
-                            'vcc_lp = "vcc"',
-                            'skip_mux_detect = "yes"',
-                            'force_bus_start = <40>',
-                        ])
-                        .nodes(self.i2c_channels)
-                ]),
-            FragmentNode(target_path='/bus@0/i2c@3180000')
-                .overlay_properties([
-                    'status = "okay"',
-                    '#address-cells = <1>',
-                    '#size-cells = <0>',
-                ])
-                .overlay_nodes([
-                    DeviceTreeNode('tca9539@74', label='tca9539_74')
-                        .properties([
-                            'compatible = "ti,tca9539"',
-                            'gpio-controller',
-                            '#gpio-cells = <2>',
-                            'ngpios = <16>',
-                            'reg = <0x74>',
-                            'status = "okay"',
-                        ])
-                        .nodes([
-                            DeviceTreeNode('tca9539_74_outlow')
-                                .properties([
-                                    'status = "okay"',
-                                    'gpio-hog',
-                                    'output-low',
-                                ]),
-                            DeviceTreeNode('ca9539_74_outhigh')
-                                .properties(['status = "disabled"']),
-                            DeviceTreeNode('tca9539_74_input')
-                                .properties(['status = "disabled"']),
-                        ])
-                ])
-        ]
-
-
 def generate_jetson_camera_overlay(opts: GeneratorOptions) -> DeviceTreeNode:
     num_channels = opts.number_of_cameras
 
@@ -240,34 +170,17 @@ def generate_jetson_camera_overlay(opts: GeneratorOptions) -> DeviceTreeNode:
     i2c_mux_path = '/i2c@31e0000/tca9544@72'
     gmsl_dsers: Sequence[DeviceTreeNode] = gmsl_dser_fragments
 
-    i2c_mux_infra: Optional[I2cMuxInfra] = None
-
     if opts.l4t_version.major >= 36:
         i2c_mux_path = '/bus@0' + i2c_mux_path
         gmsl_dsers = gmsl_dsers_nodes
-        i2c_mux_infra = I2cMuxInfra(gmsl_dsers)
-        # NOTE: the base camera DTSI (tegra-camera-base-r36.dtsi) is applied
-        # as a *separate* overlay by camera-hotplug.sh when the live tree
-        # lacks camera pipeline nodes.  It must NOT be embedded here because
-        # the kernel rejects overlay blobs where multiple fragments set the
-        # same property (e.g. status on VI ports set "disabled" by the base
-        # DTSI and "okay" by the camera fragments).
-        root.nodes(i2c_mux_infra.fragments)
+        with open(TEGRA_CAMERA_BASE_OVERLAY_R36, 'r', encoding='utf-8') as tegra_cam_dtsi:
+            (root
+                .header('\n' + tegra_cam_dtsi.read())
+                .nodes(i2c_mux_and_gmsl_dsers(gmsl_dsers)))
     else:
         root.nodes(gmsl_dsers)
 
     cameras = build_cameras(opts.camera_list, gmsl_dsers)
-
-    # For L4T >= 36, embed camera nodes directly in the I2C sub-channel
-    # DeviceTreeNode objects.  This avoids creating separate FragmentNode
-    # instances that use target-path to reference nodes created by the
-    # mux fragment — such self-referencing fails because the kernel resolves
-    # ALL target-path values before applying any overlay fragments.
-    if i2c_mux_infra is not None:
-        i2c_mux_infra.i2c_channels[3].nodes(sum(map(lambda cam: cam.to_list(), cameras[0:2]), []))
-        i2c_mux_infra.i2c_channels[2].nodes(sum(map(lambda cam: cam.to_list(), cameras[2:4]), []))
-        i2c_mux_infra.i2c_channels[1].nodes(sum(map(lambda cam: cam.to_list(), cameras[4:6]), []))
-        i2c_mux_infra.i2c_channels[0].nodes(sum(map(lambda cam: cam.to_list(), cameras[6:8]), []))
 
     graph = MediaGraph(vi_ports, nvcsi_channels, cameras)
     graph.connect_all_endpoints()
@@ -296,9 +209,144 @@ def generate_jetson_camera_overlay(opts: GeneratorOptions) -> DeviceTreeNode:
                     # string list of all the connected cameras
                     'tier4,cameras = %s' % devicetree.string_list([cam.name for cam in opts.camera_list]),
                 ]),
+
+            FragmentNode(target_path=i2c_mux_path)
+                .overlay_properties([
+                    'status = "okay"',
+                    'compatible = "nxp,pca9544"',
+                    'reg = <0x72>',
+                    '#address-cells = <1>',
+                    '#size-cells = <0>',
+                    'vcc-supply = <&vdd_1v8_sys>',
+                    'skip_mux_detect',
+                    f'force_bus_start = <{i2c_bus_number}>',
+                ]),
+            FragmentNode(target_path=f'{i2c_mux_path}/i2c@3')
+                .overlay_properties([
+                    'status = "okay"',
+                    'reg = <3>',
+                    'i2c-mux,deselect-on-exit',
+                ])
+                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[0:2]), [])),
+            FragmentNode(target_path=f'{i2c_mux_path}/i2c@2')
+                .overlay_properties([
+                    'status = "okay"',
+                    'reg = <2>',
+                    'i2c-mux,deselect-on-exit',
+                ])
+                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[2:4]), [])),
+            FragmentNode(target_path=f'{i2c_mux_path}/i2c@1')
+                .overlay_properties([
+                    'status = "okay"',
+                    'reg = <1>',
+                    'i2c-mux,deselect-on-exit',
+                ])
+                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[4:6]), [])),
+            FragmentNode(target_path=f'{i2c_mux_path}/i2c@0')
+                .overlay_properties([
+                    'status = "okay"',
+                    'reg = <0>',
+                    'i2c-mux,deselect-on-exit',
+                ])
+                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[6:8]), []))
         ]))
 
     return root
+
+
+def i2c_mux_and_gmsl_dsers(gmsl_dsers: Sequence[DeviceTreeNode]) -> List[FragmentNode]:
+    return ([
+        FragmentNode(target_path='/bus@0/i2c@31e0000')
+            .overlay_nodes([
+                DeviceTreeNode('tca9544@72')
+                    .properties([
+                        'status = "okay"',
+                        'compatible = "nxp,pca9544"',
+                        'reg = <0x72>',
+                        '#address-cells = <1>',
+                        '#size-cells = <0>',
+                        'vcc-supply = <&vdd_1v8_sys>',
+                        'vcc_lp = "vcc"',
+                        'skip_mux_detect = "yes"',
+                        'force_bus_start = <40>',
+                    ])
+                    .nodes([
+                        DeviceTreeNode('i2c@0')
+                            .properties([
+                                'status = "okay"',
+                                'reg = <0>',
+                                'i2c-mux,deselect-on-exit',
+                                '#address-cells = <1>',
+                                '#size-cells = <0>',
+                            ])
+                            .nodes([
+                                gmsl_dsers[0]
+                            ]),
+                        DeviceTreeNode('i2c@1')
+                            .properties([
+                                'status = "okay"',
+                                'reg = <1>',
+                                'i2c-mux,deselect-on-exit',
+                                '#address-cells = <1>',
+                                '#size-cells = <0>',
+                            ])
+                            .nodes([
+                                gmsl_dsers[1]
+                            ]),
+                        DeviceTreeNode('i2c@2')
+                            .properties([
+                                'status = "okay"',
+                                'reg = <2>',
+                                'i2c-mux,deselect-on-exit',
+                                '#address-cells = <1>',
+                                '#size-cells = <0>',
+                            ])
+                            .nodes([
+                                gmsl_dsers[2]
+                            ]),
+                        DeviceTreeNode('i2c@3')
+                            .properties([
+                                'status = "okay"',
+                                'reg = <3>',
+                                'i2c-mux,deselect-on-exit',
+                                '#address-cells = <1>',
+                                '#size-cells = <0>',
+                            ])
+                            .nodes([
+                                gmsl_dsers[3]
+                            ]),
+                    ])
+            ]),
+            FragmentNode(target_path='/bus@0/i2c@3180000')
+                .overlay_properties([
+                    'status = "okay"',
+                    '#address-cells = <1>',
+                    '#size-cells = <0>',
+                ])
+                .overlay_nodes([
+                    DeviceTreeNode('tca9539@74', label='tca9539_74')
+                        .properties([
+                            'compatible = "ti,tca9539"',
+                            'gpio-controller',
+                            '#gpio-cells = <2>',
+                            'ngpios = <16>',
+                            'reg = <0x74>',
+                            'status = "okay"',
+                        ])
+                        .nodes([
+                            DeviceTreeNode('tca9539_74_outlow')
+                                .properties([
+                                    'status = "okay"',
+                                    'gpio-hog',
+                                    'output-low',
+                                ]),
+                            DeviceTreeNode('ca9539_74_outhigh')
+                                .properties(['status = "disabled"']),
+                            DeviceTreeNode('tca9539_74_input')
+                                .properties(['status = "disabled"']),
+                        ])
+                ])
+        ])
 
 
 if __name__ == '__main__':

--- a/tools/dts_generator/make_overlay_dts_anvil.py
+++ b/tools/dts_generator/make_overlay_dts_anvil.py
@@ -8,6 +8,7 @@ Jetson camera devicetree overlay generator for CTI Anvil.
     * 43-003c, the 8th camera node on the 4th (out of 4) i2c mux bus corresponds to the camera connected to the GMSL port 1
 """
 
+import os
 import sys
 from typing import Dict, Iterable, List, Optional, Sequence, TypeVar
 
@@ -24,7 +25,8 @@ from dts_generator.tegra_nvcsi import NvcsiChannel
 from dts_generator.tegra_vi import CameraPlatform, ViPort
 
 PLATFORM_NAME: str = 'Anvil'
-TEGRA_CAMERA_BASE_OVERLAY_R36: str = 'dtsi/tegra-camera-base-r36.dtsi'
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+TEGRA_CAMERA_BASE_OVERLAY_R36: str = os.path.join(_SCRIPT_DIR, 'dtsi', 'tegra-camera-base-r36.dtsi')
 
 CSI_LANES: int = 4
 NUM_GMSL_DESERIALIZERS: int = 4
@@ -131,6 +133,76 @@ gmsl_dser_fragments = [
 ]
 
 
+class I2cMuxInfra:
+    """Holds references to the I2C mux sub-channel nodes so that camera nodes
+    can be added after the camera list is built.  This avoids creating separate
+    FragmentNode instances that use target-path to reference nodes created by
+    the mux fragment — the kernel resolves ALL target-path values before
+    applying any overlay fragments, so self-referencing paths fail."""
+
+    def __init__(self, gmsl_dsers: Sequence[DeviceTreeNode]) -> None:
+        self.i2c_channels = [
+            DeviceTreeNode(f'i2c@{i}')
+                .properties([
+                    'status = "okay"',
+                    f'reg = <{i}>',
+                    'i2c-mux,deselect-on-exit',
+                    '#address-cells = <1>',
+                    '#size-cells = <0>',
+                ])
+                .nodes([gmsl_dsers[i]])
+            for i in range(4)
+        ]
+
+        self.fragments: List[FragmentNode] = [
+            FragmentNode(target_path='/bus@0/i2c@31e0000')
+                .overlay_nodes([
+                    DeviceTreeNode('tca9544@72')
+                        .properties([
+                            'status = "okay"',
+                            'compatible = "nxp,pca9544"',
+                            'reg = <0x72>',
+                            '#address-cells = <1>',
+                            '#size-cells = <0>',
+                            'vcc-supply = <&vdd_1v8_sys>',
+                            'vcc_lp = "vcc"',
+                            'skip_mux_detect = "yes"',
+                            'force_bus_start = <40>',
+                        ])
+                        .nodes(self.i2c_channels)
+                ]),
+            FragmentNode(target_path='/bus@0/i2c@3180000')
+                .overlay_properties([
+                    'status = "okay"',
+                    '#address-cells = <1>',
+                    '#size-cells = <0>',
+                ])
+                .overlay_nodes([
+                    DeviceTreeNode('tca9539@74', label='tca9539_74')
+                        .properties([
+                            'compatible = "ti,tca9539"',
+                            'gpio-controller',
+                            '#gpio-cells = <2>',
+                            'ngpios = <16>',
+                            'reg = <0x74>',
+                            'status = "okay"',
+                        ])
+                        .nodes([
+                            DeviceTreeNode('tca9539_74_outlow')
+                                .properties([
+                                    'status = "okay"',
+                                    'gpio-hog',
+                                    'output-low',
+                                ]),
+                            DeviceTreeNode('ca9539_74_outhigh')
+                                .properties(['status = "disabled"']),
+                            DeviceTreeNode('tca9539_74_input')
+                                .properties(['status = "disabled"']),
+                        ])
+                ])
+        ]
+
+
 def generate_jetson_camera_overlay(opts: GeneratorOptions) -> DeviceTreeNode:
     num_channels = opts.number_of_cameras
 
@@ -168,17 +240,34 @@ def generate_jetson_camera_overlay(opts: GeneratorOptions) -> DeviceTreeNode:
     i2c_mux_path = '/i2c@31e0000/tca9544@72'
     gmsl_dsers: Sequence[DeviceTreeNode] = gmsl_dser_fragments
 
+    i2c_mux_infra: Optional[I2cMuxInfra] = None
+
     if opts.l4t_version.major >= 36:
         i2c_mux_path = '/bus@0' + i2c_mux_path
         gmsl_dsers = gmsl_dsers_nodes
-        with open(TEGRA_CAMERA_BASE_OVERLAY_R36, 'r', encoding='utf-8') as tegra_cam_dtsi:
-            (root
-                .header('\n' + tegra_cam_dtsi.read())
-                .nodes(i2c_mux_and_gmsl_dsers(gmsl_dsers)))
+        i2c_mux_infra = I2cMuxInfra(gmsl_dsers)
+        # NOTE: the base camera DTSI (tegra-camera-base-r36.dtsi) is applied
+        # as a *separate* overlay by camera-hotplug.sh when the live tree
+        # lacks camera pipeline nodes.  It must NOT be embedded here because
+        # the kernel rejects overlay blobs where multiple fragments set the
+        # same property (e.g. status on VI ports set "disabled" by the base
+        # DTSI and "okay" by the camera fragments).
+        root.nodes(i2c_mux_infra.fragments)
     else:
         root.nodes(gmsl_dsers)
 
     cameras = build_cameras(opts.camera_list, gmsl_dsers)
+
+    # For L4T >= 36, embed camera nodes directly in the I2C sub-channel
+    # DeviceTreeNode objects.  This avoids creating separate FragmentNode
+    # instances that use target-path to reference nodes created by the
+    # mux fragment — such self-referencing fails because the kernel resolves
+    # ALL target-path values before applying any overlay fragments.
+    if i2c_mux_infra is not None:
+        i2c_mux_infra.i2c_channels[3].nodes(sum(map(lambda cam: cam.to_list(), cameras[0:2]), []))
+        i2c_mux_infra.i2c_channels[2].nodes(sum(map(lambda cam: cam.to_list(), cameras[2:4]), []))
+        i2c_mux_infra.i2c_channels[1].nodes(sum(map(lambda cam: cam.to_list(), cameras[4:6]), []))
+        i2c_mux_infra.i2c_channels[0].nodes(sum(map(lambda cam: cam.to_list(), cameras[6:8]), []))
 
     graph = MediaGraph(vi_ports, nvcsi_channels, cameras)
     graph.connect_all_endpoints()
@@ -207,144 +296,9 @@ def generate_jetson_camera_overlay(opts: GeneratorOptions) -> DeviceTreeNode:
                     # string list of all the connected cameras
                     'tier4,cameras = %s' % devicetree.string_list([cam.name for cam in opts.camera_list]),
                 ]),
-
-            FragmentNode(target_path=i2c_mux_path)
-                .overlay_properties([
-                    'status = "okay"',
-                    'compatible = "nxp,pca9544"',
-                    'reg = <0x72>',
-                    '#address-cells = <1>',
-                    '#size-cells = <0>',
-                    'vcc-supply = <&vdd_1v8_sys>',
-                    'skip_mux_detect',
-                    f'force_bus_start = <{i2c_bus_number}>',
-                ]),
-            FragmentNode(target_path=f'{i2c_mux_path}/i2c@3')
-                .overlay_properties([
-                    'status = "okay"',
-                    'reg = <3>',
-                    'i2c-mux,deselect-on-exit',
-                ])
-                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[0:2]), [])),
-            FragmentNode(target_path=f'{i2c_mux_path}/i2c@2')
-                .overlay_properties([
-                    'status = "okay"',
-                    'reg = <2>',
-                    'i2c-mux,deselect-on-exit',
-                ])
-                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[2:4]), [])),
-            FragmentNode(target_path=f'{i2c_mux_path}/i2c@1')
-                .overlay_properties([
-                    'status = "okay"',
-                    'reg = <1>',
-                    'i2c-mux,deselect-on-exit',
-                ])
-                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[4:6]), [])),
-            FragmentNode(target_path=f'{i2c_mux_path}/i2c@0')
-                .overlay_properties([
-                    'status = "okay"',
-                    'reg = <0>',
-                    'i2c-mux,deselect-on-exit',
-                ])
-                .overlay_nodes(sum(map(lambda cam: cam.to_list(), cameras[6:8]), []))
         ]))
 
     return root
-
-
-def i2c_mux_and_gmsl_dsers(gmsl_dsers: Sequence[DeviceTreeNode]) -> List[FragmentNode]:
-    return ([
-        FragmentNode(target_path='/bus@0/i2c@31e0000')
-            .overlay_nodes([
-                DeviceTreeNode('tca9544@72')
-                    .properties([
-                        'status = "okay"',
-                        'compatible = "nxp,pca9544"',
-                        'reg = <0x72>',
-                        '#address-cells = <1>',
-                        '#size-cells = <0>',
-                        'vcc-supply = <&vdd_1v8_sys>',
-                        'vcc_lp = "vcc"',
-                        'skip_mux_detect = "yes"',
-                        'force_bus_start = <40>',
-                    ])
-                    .nodes([
-                        DeviceTreeNode('i2c@0')
-                            .properties([
-                                'status = "okay"',
-                                'reg = <0>',
-                                'i2c-mux,deselect-on-exit',
-                                '#address-cells = <1>',
-                                '#size-cells = <0>',
-                            ])
-                            .nodes([
-                                gmsl_dsers[0]
-                            ]),
-                        DeviceTreeNode('i2c@1')
-                            .properties([
-                                'status = "okay"',
-                                'reg = <1>',
-                                'i2c-mux,deselect-on-exit',
-                                '#address-cells = <1>',
-                                '#size-cells = <0>',
-                            ])
-                            .nodes([
-                                gmsl_dsers[1]
-                            ]),
-                        DeviceTreeNode('i2c@2')
-                            .properties([
-                                'status = "okay"',
-                                'reg = <2>',
-                                'i2c-mux,deselect-on-exit',
-                                '#address-cells = <1>',
-                                '#size-cells = <0>',
-                            ])
-                            .nodes([
-                                gmsl_dsers[2]
-                            ]),
-                        DeviceTreeNode('i2c@3')
-                            .properties([
-                                'status = "okay"',
-                                'reg = <3>',
-                                'i2c-mux,deselect-on-exit',
-                                '#address-cells = <1>',
-                                '#size-cells = <0>',
-                            ])
-                            .nodes([
-                                gmsl_dsers[3]
-                            ]),
-                    ])
-            ]),
-            FragmentNode(target_path='/bus@0/i2c@3180000')
-                .overlay_properties([
-                    'status = "okay"',
-                    '#address-cells = <1>',
-                    '#size-cells = <0>',
-                ])
-                .overlay_nodes([
-                    DeviceTreeNode('tca9539@74', label='tca9539_74')
-                        .properties([
-                            'compatible = "ti,tca9539"',
-                            'gpio-controller',
-                            '#gpio-cells = <2>',
-                            'ngpios = <16>',
-                            'reg = <0x74>',
-                            'status = "okay"',
-                        ])
-                        .nodes([
-                            DeviceTreeNode('tca9539_74_outlow')
-                                .properties([
-                                    'status = "okay"',
-                                    'gpio-hog',
-                                    'output-low',
-                                ]),
-                            DeviceTreeNode('ca9539_74_outhigh')
-                                .properties(['status = "disabled"']),
-                            DeviceTreeNode('tca9539_74_input')
-                                .properties(['status = "disabled"']),
-                        ])
-                ])
-        ])
 
 
 if __name__ == '__main__':

--- a/tools/dts_generator/make_overlay_dts_orin-devkit-r36.py
+++ b/tools/dts_generator/make_overlay_dts_orin-devkit-r36.py
@@ -3,6 +3,7 @@
 Jetson camera devicetree overlay generator for Jetson AGX Orin Developer Kit.
 """
 
+import os
 import sys
 from typing import Dict, Iterable, List, Optional, Sequence, TypeVar
 
@@ -19,7 +20,8 @@ from dts_generator.tegra_nvcsi import NvcsiChannel
 from dts_generator.tegra_vi import CameraPlatform, ViPort
 
 PLATFORM_NAME: str = 'orin-devkit'
-TEGRA_CAMERA_BASE_OVERLAY_R36: str = 'dtsi/tegra-camera-base-r36.dtsi'
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+TEGRA_CAMERA_BASE_OVERLAY_R36: str = os.path.join(_SCRIPT_DIR, 'dtsi', 'tegra-camera-base-r36.dtsi')
 
 CSI_LANES: int = 4
 NUM_GMSL_DESERIALIZERS: int = 4


### PR DESCRIPTION
## Summary

Enable runtime DT overlay application for camera hotplug on CTI Anvil (Orin AGX, L4T R36.4.0).

**New tools:**
- `adapt_overlay_for_runtime.py` — transforms boot-time DTS overlays for kernel runtime: resolves `target-path` against live device tree, rolls up missing paths, deep-merges fragments targeting the same node
- `dedup_overlay_dts.py` — removes label definitions conflicting with live tree's `__symbols__` to avoid phandle conflicts in `overlay.c`
- Both scripts must run on the target device (read `/proc/device-tree/`)

**Hotplug script updates (`camera-hotplug.sh`):**
- Full camera stack unload/reload with correct module ordering
- Fix: `modprobe` (load) only accepts one module per call — use separate invocations
- GMSL serdes reset (MAX9296 RESET_ALL via i2cset + `tier4_max9296`/`tier4_max9295` module reload) for runtime overlay switching
- `tegra-camera` / `tegra_camera_platform` / `nvhost-capture` / `nvhost-nvcsi` stay resident (host1x binding refs prevent unload)

**Generator fixes:**
- Fix relative path bug in `make_overlay_dts_anvil.py` and `make_overlay_dts_orin-devkit-r36.py`
- Revert generator to v2.1.0 structure (restore base DTSI embedding for boot-time compatibility)

**Note:** Runtime overlay switching also requires kernel patches (§1-§4) in the companion PR: https://github.com/tier4/linux-cti-anvil/pull/5

**Detailed analysis (TIER IV internal URL):** https://tier4.atlassian.net/wiki/x/LYI6KQE

## Known limitations (follow-up PRs)

- `i2cset` GMSL reset in `camera-hotplug.sh` is a workaround — should be moved to kernel driver (MAX9296 probe or dedicated reset function)
- I2C bus numbers (10-13) are hardcoded for CTI Anvil — needs parameterization for other boards
- Whether `i2cset` is truly necessary (vs serdes module reload alone) has not been verified in a clean environment
- `tier4_max9295_check_sensor_error` workqueue crashes on overlay removal — needs `cancel_delayed_work_sync`

## Test plan

- [x] E2E test: fresh boot → `camera-hotplug.sh anvil R36.4.0 -8 C1` → `/dev/video0` appears, `media-ctl -p` shows pipeline
- [x] E2E test: fresh boot → C2 overlay → image capture succeeds
- [x] Runtime overlay switch: C1 → C2 → C1 with image capture at each step
- [x] Runtime overlay switch after streaming (§4 kernel fix required)
- [ ] Test with other board generators (`make_overlay_dts_orin-devkit-r36.py`)